### PR TITLE
Removed requirement for Bootstrap

### DIFF
--- a/src/bulma-stubs/app.js
+++ b/src/bulma-stubs/app.js
@@ -5,7 +5,7 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap');
+//require('./bootstrap');
 
 // window.Vue = require('vue');
 


### PR DESCRIPTION
There's no real need for this requirement since we already have the extensions JS and Bulma is supposed to be mainly CSS only.